### PR TITLE
Checklist tweaks

### DIFF
--- a/Sources/AttributedStringBuilder/Attributes.swift
+++ b/Sources/AttributedStringBuilder/Attributes.swift
@@ -8,7 +8,7 @@ import AppKit
 
 /// Attributes for `NSAttributedString`, wrapped in a struct for convenience.
 public struct Attributes {
-    public init(family: String = "Helvetica", size: CGFloat = 14, bold: Bool = false, italic: Bool = false, textColor: NSColor = .textColor, backgroundColor: NSColor? = nil, kern: CGFloat = 0, firstlineHeadIndent: CGFloat = 0, headIndent: CGFloat = 0, tabStops: [NSTextTab] = (1..<10).map { NSTextTab(textAlignment: .left, location: CGFloat($0) * 2 * 16) }, alignment: NSTextAlignment = .left, lineHeightMultiple: CGFloat = 1.3, minimumLineHeight: CGFloat? = nil, maximumLineHeight: CGFloat? = nil, paragraphSpacing: CGFloat = 0, paragraphSpacingBefore: CGFloat = 0, link: URL? = nil) {
+    public init(family: String = "Helvetica", size: CGFloat = 14, bold: Bool = false, italic: Bool = false, textColor: NSColor = .textColor, backgroundColor: NSColor? = nil, kern: CGFloat = 0, firstlineHeadIndent: CGFloat = 0, headIndent: CGFloat = 0, tabStops: [NSTextTab] = (1..<10).map { NSTextTab(textAlignment: .left, location: CGFloat($0) * 2 * 16) }, alignment: NSTextAlignment = .left, lineHeightMultiple: CGFloat = 1.3, minimumLineHeight: CGFloat? = nil, maximumLineHeight: CGFloat? = nil, paragraphSpacing: CGFloat = 14, paragraphSpacingBefore: CGFloat = 0, link: URL? = nil, cursor: NSCursor? = nil) {
         self.family = family
         self.size = size
         self.bold = bold
@@ -26,6 +26,7 @@ public struct Attributes {
         self.paragraphSpacing = paragraphSpacing
         self.paragraphSpacingBefore = paragraphSpacingBefore
         self.link = link
+        self.cursor = cursor
     }
 
     public var family: String
@@ -45,6 +46,7 @@ public struct Attributes {
     public var paragraphSpacing: CGFloat = 0
     public var paragraphSpacingBefore: CGFloat = 0
     public var link: URL? = nil
+    public var cursor: NSCursor? = nil
     public var customAttributes: [String: Any] = [:]
 }
 
@@ -92,6 +94,9 @@ extension Attributes {
         }
         if let url = link {
             result[.link] = url
+        }
+        if let cursor {
+            result[.cursor] = cursor
         }
         for (key, value) in customAttributes {
             result[NSAttributedString.Key(key)] = value

--- a/Sources/AttributedStringBuilder/Markdown.swift
+++ b/Sources/AttributedStringBuilder/Markdown.swift
@@ -132,8 +132,7 @@ struct AttributedStringWalker: MarkupWalker {
             let prefix: String
             var prefixAttributes = attributes
             
-            switch (item.checkbox, isOrdered) {
-            case (let checkbox?, _):
+            if let checkbox = item.checkbox {
                 switch checkbox {
                 case .checked:
                     prefix = stylesheet.checkboxCheckedPrefix
@@ -145,12 +144,14 @@ struct AttributedStringWalker: MarkupWalker {
                 if let url = makeCheckboxURL?(item) {
                     prefixAttributes.link = url
                 }
-            case (_, true):
-                prefix = stylesheet.orderedListItemPrefix(number: number)
-                stylesheet.orderedListItemPrefix(attributes: &prefixAttributes)
-            case (_, false):
-                prefix = stylesheet.unorderedListItemPrefix
-                stylesheet.unorderedListItemPrefix(attributes: &prefixAttributes)
+            } else {
+                if isOrdered {
+                    stylesheet.orderedListItemPrefix(attributes: &prefixAttributes)
+                    prefix = stylesheet.orderedListItemPrefix(number: number)
+                } else {
+                    stylesheet.unorderedListItemPrefix(attributes: &prefixAttributes)
+                    prefix = stylesheet.unorderedListItemPrefix
+                }
             }
             
             if number == list.childCount {
@@ -159,7 +160,9 @@ struct AttributedStringWalker: MarkupWalker {
                 prefixAttributes.paragraphSpacing = original.paragraphSpacing
             }
             
-            attributedString.append(NSAttributedString(string: "\t\(prefix)\t", attributes: prefixAttributes))
+            attributedString.append(NSAttributedString(string: "\t", attributes: attributes))
+            attributedString.append(NSAttributedString(string: prefix, attributes: prefixAttributes))
+            attributedString.append(NSAttributedString(string: "\t", attributes: attributes))
 
             // Visit list item contents
             visit(item)

--- a/Sources/AttributedStringBuilder/MarkdownStylesheet.swift
+++ b/Sources/AttributedStringBuilder/MarkdownStylesheet.swift
@@ -66,21 +66,23 @@ extension Stylesheet {
     public func unorderedListItemPrefix(attributes: inout Attributes) { }
     
     public var checkboxCheckedPrefix: String {
-        "􀃳"
+        "[x]" // TODO: fix NSTextView image clicks for "􀃳"
     }
     
     public func checkboxCheckedPrefix(attributes: inout Attributes) {
         attributes.textColor = .controlAccentColor
         attributes.cursor = .arrow
+        attributes.family = "Monaco" // monospaced
     }
     
     public var checkboxUncheckedPrefix: String {
-        "􀂒"
+        "[ ]" // TODO: fix NSTextView image clicks for "􀂒"
     }
     
     public func checkboxUncheckedPrefix(attributes: inout Attributes) {
         attributes.textColor = .secondaryLabelColor
         attributes.cursor = .arrow
+        attributes.family = "Monaco" // monospaced
     }
 
     public func footnote(attributes: inout Attributes) {

--- a/Sources/AttributedStringBuilder/MarkdownStylesheet.swift
+++ b/Sources/AttributedStringBuilder/MarkdownStylesheet.swift
@@ -71,6 +71,7 @@ extension Stylesheet {
     
     public func checkboxCheckedPrefix(attributes: inout Attributes) {
         attributes.textColor = .controlAccentColor
+        attributes.cursor = .arrow
     }
     
     public var checkboxUncheckedPrefix: String {
@@ -79,6 +80,7 @@ extension Stylesheet {
     
     public func checkboxUncheckedPrefix(attributes: inout Attributes) {
         attributes.textColor = .secondaryLabelColor
+        attributes.cursor = .arrow
     }
 
     public func footnote(attributes: inout Attributes) {


### PR DESCRIPTION
Rendering checkboxes using ascii characters, so that an `NSTextView` representable view may be used to make paragraph spacing work.

This also tweaks the styling of a checkbox by showing an arrow cursor and using different colors per state.