### PR TITLE
Mark `MarkdownString.pieces` public and add pieces initializer

### DIFF
--- a/Sources/AttributedStringBuilder/MarkdownString.swift
+++ b/Sources/AttributedStringBuilder/MarkdownString.swift
@@ -2,14 +2,14 @@
 
 import Foundation
 
-enum Piece {
+public enum Piece {
     case raw(String)
     case component(any AttributedStringConvertible)
 }
 
 // This is a string-like type that allows for interpolation of custom segments that conform to AttributedStringConvertible.
 public struct MarkdownString: ExpressibleByStringInterpolation {
-    var pieces: [Piece] = []
+    public var pieces: [Piece] = []
 
     public init(stringLiteral value: String) {
         pieces = [.raw(value)]
@@ -17,6 +17,10 @@ public struct MarkdownString: ExpressibleByStringInterpolation {
 
     public init(stringInterpolation: Interpolation) {
         pieces = stringInterpolation.pieces
+    }
+    
+    public init(pieces: [Piece]) {
+        self.pieces = pieces
     }
 
     public struct Interpolation: StringInterpolationProtocol {


### PR DESCRIPTION
So we can perform some mapping and create a new markdown string based on the current values.

### Detail

I want to manipulate the `MarkdownString` instance and update its content (especially the `raw` content). This PR adds a way to do so.

```swift
let markdown: MarkdownString = """
Hello world.
"""

let pieces = markdown.pieces.map { p in
    switch p {
    case .raw(let raw):
        return Piece.raw("你好，世界")
    case .component:
        return p
    }
}
MarkdownString(pieces: pieces)
```