### PR TITLE
Allow font creation to fail and fallback to a safe font

### DIFF
--- a/Sources/AttributedStringBuilder/Attributes.swift
+++ b/Sources/AttributedStringBuilder/Attributes.swift
@@ -104,7 +104,10 @@ extension Attributes {
         if bold { traits.formUnion(.bold) }
         if italic { traits.formUnion(.italic )}
         if !traits.isEmpty { fontDescriptor = fontDescriptor.withSymbolicTraits(traits) }
-        let font = NSFont(descriptor: fontDescriptor, size: size)!
+        guard let font = NSFont(descriptor: fontDescriptor, size: size) else {
+            print("Font creation with traits failed: \(traits). Fallback to named font.")
+            return NSFont(name: family, size: size) ?? .systemFont(ofSize: size)
+        }
         return font
     }
 


### PR DESCRIPTION
For some languages (such as CJK), there is no "italic" version of the font. For these fonts, if the `traits` contains `.italic`, `NSFont.init(descriptor:size:)` will fail to create the font and return `nil`.

I understand that it can be an "author error" to use a font without italic version, but use `*some word*` to make text italic. But I guess a hard crash for this error is too strict. Unless modifying every italic case in the original text, I won't be able to use a new font, which is not ideal and painful.