### PR TITLE
Mark `Modify` type and its contents as public

### DIFF
--- a/Sources/AttributedStringBuilder/Modify.swift
+++ b/Sources/AttributedStringBuilder/Modify.swift
@@ -1,10 +1,10 @@
 import AppKit
 
-struct Modify: AttributedStringConvertible {
+public struct Modify: AttributedStringConvertible {
     var modify: (inout Attributes) -> ()
-    var contents: AttributedStringConvertible
+    public var contents: AttributedStringConvertible
 
-    func attributedString(context: inout Context) -> [NSAttributedString] {
+    public func attributedString(context: inout Context) -> [NSAttributedString] {
         let old = context.environment.attributes
         defer { context.environment.attributes = old }
         modify(&context.environment.attributes)


### PR DESCRIPTION
So we can do a runtime replacement for its content, just like other `AttributedStringConvertible` conforming types.

In the current existing implementation, as a library user, if a `Piece.component` is given, we can perform some type check and determine whether we should replace its content:

```swift
switch piece {
case .raw(let origin):
    return Piece.raw("another")
case .component(let value):
    // Check if `value` is `String`
    if let s = value as? String {
        return Piece.component("some value")
    } else {
        return Piece.raw("")
    }
}
```

However, when the component contains a `Modify` value, since it is now an internal type, there is no way to give it a new value at runtime (e.g, for translation purpose).

With this PR, we can now do things like:

```swift
if let m = value as? Modify {
    var modify = m
    if let s = modify.contents as? String {
        modify.contents = "Some other string"
        return .component(modify)
    }
}
```