### PR TITLE
Add support for preferred color scheme to SwiftUI Embed

### DIFF
--- a/Sources/AttributedStringBuilder/Attributes.swift
+++ b/Sources/AttributedStringBuilder/Attributes.swift
@@ -5,6 +5,7 @@
 //  Created by Juul Spee on 08/07/2022.
 
 import AppKit
+import SwiftUI
 
 /// Attributes for `NSAttributedString`, wrapped in a struct for convenience.
 public struct Attributes {
@@ -34,7 +35,8 @@ public struct Attributes {
         cursor: NSCursor? = nil,
         underlineColor: NSColor? = nil,
         underlineStyle: NSUnderlineStyle? = nil,
-        suppressHeader: Bool = false) {
+        suppressHeader: Bool = false,
+        preferredEmbedColorScheme: ColorScheme? = nil) {
         self.family = family
         self.size = size
         self.bold = bold
@@ -58,6 +60,7 @@ public struct Attributes {
         self.underlineColor = underlineColor
         self.underlineStyle = underlineStyle
         self.suppressHeader = suppressHeader
+        self.preferredEmbedColorScheme = preferredEmbedColorScheme
     }
 
     public var family: String
@@ -84,6 +87,7 @@ public struct Attributes {
     public var underlineStyle: NSUnderlineStyle?
 //    public var suppressHeading: Bool?
     public var customAttributes: [String: Any] = [:]
+    public var preferredEmbedColorScheme: ColorScheme? = nil
 }
 
 extension Attributes {

--- a/Sources/AttributedStringBuilder/SwiftUI.swift
+++ b/Sources/AttributedStringBuilder/SwiftUI.swift
@@ -97,6 +97,7 @@ public struct Embed<V: View>: AttributedStringConvertible {
     public func attributedString(context: inout Context) -> [NSAttributedString] {
         let proposal = self.proposal ?? context.environment.defaultProposal
         let theView = view
+            .preferredColorScheme(context.environment.attributes.preferredEmbedColorScheme)
             .transformEnvironment(\.self, transform: context.environment.modifyEnv)
             .font(SwiftUI.Font(context.environment.attributes.computedFont))
         if bitmap {


### PR DESCRIPTION
When rendering the `Embed` with `attributedString(context:)`, it chooses the current system color scheme as the view's color scheme. Since the output PDF contains a white background, when choosing a light scheme, everything goes fine. However, if using a dark scheme, the SwiftUI `Embed` in the text would try to render with white font color for system controls. As below:

![截屏2023-07-10 22 04 10](https://github.com/objcio/attributed-string-builder/assets/1019875/0a5feae9-b59c-4e53-99d3-c43ff0df9c11)

It is a problem that the render behavior varies based on the hosting OS color scheme.

By the changes in this PR and setting the color scheme for `defaultAttributes`:

```diff
defaultAttributes = Attributes(
  family: "Helvetica",
  size: textSize,
  // ...
+ preferredEmbedColorScheme: .light
)
```

It can produces correct result even in a dark scheme system:

![截屏2023-07-10 22 06 31](https://github.com/objcio/attributed-string-builder/assets/1019875/36fee727-fb5d-4936-9934-f38076d57843)

---

We also have an option to explicitly adding it to the use case of `Embed` in the client, such as:


```diff
Embed(proposal: .init(width: pageWidth*2, height: nil), scale: 0.5, bitmap: true) {
+   Text("Hello").preferredColorScheme(.light)
}
```

But I think it is a heavy burden to remember it every time.

Or we can hard-code it into the `attributedString(context:)` method:

```diff
let theView = view
+          .preferredColorScheme(.light)
            .transformEnvironment(\.self, transform: context.environment.modifyEnv)
            .font(SwiftUI.Font(context.environment.attributes.computedFont))
```

However, I guess it can be too cumbersome. If later we want a Dark-mode of book, it is again a pain.

Let me know if you have a better place for it.