### PR TITLE
Do not skip link annotation when encountering a failing case

### DIFF
--- a/Sources/AttributedStringBuilder/AddOutline.swift
+++ b/Sources/AttributedStringBuilder/AddOutline.swift
@@ -72,7 +72,7 @@ extension PDFDocument {
         for l in links {
             guard let dest = namedParts.first(where: { $0.name == l.name }) else {
                 print("No destination named: \(l.name)")
-                return
+                continue
             }
             let sourcePage = page(at: l.pageNumber)!
             let page = page(at: dest.pageNumber)!


### PR DESCRIPTION
For now, if one of the links fails to find a destination, the whole `addLinks` method is returned. It causes any following links are not correctly appended, which should not be the desired behavior.